### PR TITLE
Support for channels using custom url & MutationObserver should be always registered

### DIFF
--- a/add-members-only-videos-list-button.js
+++ b/add-members-only-videos-list-button.js
@@ -46,21 +46,20 @@
         let targetURL;
         let href = location.href;
         if (/\/\/[^\/]+\/c(hannel)?\//.test(href)) {
-            addLink(window.ytInitialData.header.c4TabbedHeaderRenderer.channelId);
-        } else {
-            if (window.MutationObserver) {
-                let observer = new MutationObserver(function(mutations) {
-                    mutations.forEach(mutation => {
-                        if (mutation.type == 'childList') {
-                            mutation.addedNodes.forEach(node => {
-                                // tp-yt-app-header.style-scope.ytd-c4-tabbed-header-renderer
-                                if (node.tagName == "TP-YT-APP-HEADER" && node.className == "style-scope ytd-c4-tabbed-header-renderer") { addLink(); }
-                            });
-                        }
-                    });
+            addLink();
+        }
+        if (window.MutationObserver) {
+            let observer = new MutationObserver(function(mutations) {
+                mutations.forEach(mutation => {
+                    if (mutation.type == 'childList') {
+                        mutation.addedNodes.forEach(node => {
+                            // tp-yt-app-header.style-scope.ytd-c4-tabbed-header-renderer
+                            if (node.tagName == "TP-YT-APP-HEADER" && node.className == "style-scope ytd-c4-tabbed-header-renderer") { addLink(); }
+                        });
+                    }
                 });
-                observer.observe(document.querySelector('body'), { "childList": true, "subtree": true });
-            }
+            });
+            observer.observe(document.querySelector('body'), { "childList": true, "subtree": true });
         }
     };
 })();

--- a/add-members-only-videos-list-button.js
+++ b/add-members-only-videos-list-button.js
@@ -14,7 +14,7 @@
 (function() {
     'use strict';
     window.onload = function() {
-        function addLink() {
+        function addLink(chId) {
             const displayTextMap = {
                 'zh-Hant-TW': '會限清單',
                 'zh-Hant-HK': '會限清單',
@@ -37,8 +37,7 @@
             const target = document.querySelector("tp-yt-paper-tab:nth-last-of-type(3)");
 
             target.addEventListener('click', function() {
-                const listId = window.ytInitialData.header.c4TabbedHeaderRenderer.channelId.replace(/^UC/, 'UUMO');
-                const targetURL = `${location.protocol}//${location.host}/playlist?list=${listId}`;
+                const targetURL = `${location.protocol}//${location.host}/playlist?list=${chId.replace(/^UC/, 'UUMO')}`;
                 window.open(targetURL);
             });
         }
@@ -46,21 +45,22 @@
         let targetURL;
         let href = location.href;
         if (/\/\/[^\/]+\/c(hannel)?\//.test(href)) {
-            addLink();
-        } else {
-            if (window.MutationObserver) {
-                let observer = new MutationObserver(function(mutations) {
-                    mutations.forEach(mutation => {
-                        if (mutation.type == 'childList') {
-                            mutation.addedNodes.forEach(node => {
-                                // tp-yt-app-header.style-scope.ytd-c4-tabbed-header-renderer
-                                if (node.tagName == "TP-YT-APP-HEADER" && node.className == "style-scope ytd-c4-tabbed-header-renderer") { addLink(); }
-                            });
-                        }
-                    });
+            addLink(window.ytInitialData.header.c4TabbedHeaderRenderer.channelId);
+        }
+        if (window.MutationObserver) {
+            let observer = new MutationObserver(function(mutations) {
+                mutations.forEach(mutation => {
+                    if (mutation.type == 'childList') {
+                        mutation.addedNodes.forEach(node => {
+                            // tp-yt-app-header.style-scope.ytd-c4-tabbed-header-renderer
+                            if (node.tagName == "TP-YT-APP-HEADER" && node.className == "style-scope ytd-c4-tabbed-header-renderer") {
+                                addLink(node.__dataHost.__data.data.channelId);
+                            }
+                        });
+                    }
                 });
-                observer.observe(document.querySelector('body'), { "childList": true, "subtree": true });
-            }
+            });
+            observer.observe(document.querySelector('body'), { "childList": true, "subtree": true });
         }
     };
 })();

--- a/add-members-only-videos-list-button.js
+++ b/add-members-only-videos-list-button.js
@@ -37,14 +37,15 @@
             const target = document.querySelector("tp-yt-paper-tab:nth-last-of-type(3)");
 
             target.addEventListener('click', function() {
-                let targetURL = `${location.protocol}//${location.host}/playlist?list=${location.pathname.split('/')[2].replace(/^UC/, 'UUMO')}`;
+                const listId = window.ytInitialData.header.c4TabbedHeaderRenderer.channelId.replace(/^UC/, 'UUMO');
+                const targetURL = `${location.protocol}//${location.host}/playlist?list=${listId}`;
                 window.open(targetURL);
             });
         }
 
         let targetURL;
         let href = location.href;
-        if (/\/channel\//.test(href)) {
+        if (/\/\/[^\/]+\/c(hannel)?\//.test(href)) {
             addLink();
         } else {
             if (window.MutationObserver) {

--- a/add-members-only-videos-list-button.js
+++ b/add-members-only-videos-list-button.js
@@ -14,7 +14,7 @@
 (function() {
     'use strict';
     window.onload = function() {
-        function addLink(chId) {
+        function addLink() {
             const displayTextMap = {
                 'zh-Hant-TW': '會限清單',
                 'zh-Hant-HK': '會限清單',
@@ -37,6 +37,7 @@
             const target = document.querySelector("tp-yt-paper-tab:nth-last-of-type(3)");
 
             target.addEventListener('click', function() {
+                const chId = document.querySelector("ytd-c4-tabbed-header-renderer").__data.data.channelId;
                 const targetURL = `${location.protocol}//${location.host}/playlist?list=${chId.replace(/^UC/, 'UUMO')}`;
                 window.open(targetURL);
             });
@@ -46,21 +47,20 @@
         let href = location.href;
         if (/\/\/[^\/]+\/c(hannel)?\//.test(href)) {
             addLink(window.ytInitialData.header.c4TabbedHeaderRenderer.channelId);
-        }
-        if (window.MutationObserver) {
-            let observer = new MutationObserver(function(mutations) {
-                mutations.forEach(mutation => {
-                    if (mutation.type == 'childList') {
-                        mutation.addedNodes.forEach(node => {
-                            // tp-yt-app-header.style-scope.ytd-c4-tabbed-header-renderer
-                            if (node.tagName == "TP-YT-APP-HEADER" && node.className == "style-scope ytd-c4-tabbed-header-renderer") {
-                                addLink(node.__dataHost.__data.data.channelId);
-                            }
-                        });
-                    }
+        } else {
+            if (window.MutationObserver) {
+                let observer = new MutationObserver(function(mutations) {
+                    mutations.forEach(mutation => {
+                        if (mutation.type == 'childList') {
+                            mutation.addedNodes.forEach(node => {
+                                // tp-yt-app-header.style-scope.ytd-c4-tabbed-header-renderer
+                                if (node.tagName == "TP-YT-APP-HEADER" && node.className == "style-scope ytd-c4-tabbed-header-renderer") { addLink(); }
+                            });
+                        }
+                    });
                 });
-            });
-            observer.observe(document.querySelector('body'), { "childList": true, "subtree": true });
+                observer.observe(document.querySelector('body'), { "childList": true, "subtree": true });
+            }
         }
     };
 })();


### PR DESCRIPTION
There's no channel id for channels using custom url. Thus, get channel id from corresponding data host DOM instead.
YouTube will always prefer using custom url instead of normal url, so this patch is required.
Also, because of path of custom url starting with /c/ instead of /channel/, patched the matching rule.

As for MutationObserver, it should always registered, or button won't appear when switching from other page under some condition.
(For example, you first enter a channel page, then watch some videos from other channel, then click the channel link in the video.)