### PR TITLE
Fix for new youtube

### DIFF
--- a/add-members-only-videos-list-button.js
+++ b/add-members-only-videos-list-button.js
@@ -55,9 +55,8 @@
             }
         }
 
-        let targetURL;
         let href = location.href;
-        if (/\/\/[^\/]+\/c(hannel)?\//.test(href)) {
+        if (/\/\/[^\/]+\/(c(hannel)?|user)\//.test(href)) {
             addLink();
         }
         if (window.MutationObserver) {

--- a/add-members-only-videos-list-button.js
+++ b/add-members-only-videos-list-button.js
@@ -36,12 +36,22 @@
                 `);
                 anchorElement.parentNode.insertBefore(newNode, anchorElement);
                 const target = document.querySelector("tp-yt-paper-tab:nth-last-of-type(3)");
-
                 target.addEventListener('click', function() {
                     const chId = document.querySelector("ytd-c4-tabbed-header-renderer").__data.data.channelId;
                     const targetURL = `${location.protocol}//${location.host}/playlist?list=${chId.replace(/^UC/, 'UUMO')}`;
                     window.open(targetURL);
                 });
+
+                if (window.MutationObserver) {
+                    // monitor for rendering
+                    let observer = new MutationObserver(function(mutations) {
+                        if (!!mutations.find(mutation => mutation.type == 'childList' && (mutation.addedNodes.length || mutation.removedNodes.length))) {
+                            observer.disconnect(); // required ...
+                            addLink();
+                        }
+                    });
+                    observer.observe(document.querySelector('#tabsContent'), { "childList": true });
+                }
             }
         }
 

--- a/add-members-only-videos-list-button.js
+++ b/add-members-only-videos-list-button.js
@@ -23,24 +23,26 @@
                 'en': 'Members-only-video List'
             };
             const anchorElement = document.querySelector("tp-yt-paper-tab:nth-last-of-type(2)");
-            let displayText = displayTextMap[document.documentElement.lang] || displayTextMap.en;
-            const newNode = document.createRange().createContextualFragment(`
-                <tp-yt-paper-tab class="style-scope ytd-c4-tabbed-header-renderer" role="tab" aria-disabled="false" aria-selected="true" tabindex="0"><!--css-build:shady-->
-                    <div class="tab-content style-scope tp-yt-paper-tab">${displayText}</div>
-	                <paper-ripple class="style-scope tp-yt-paper-tab"><!--css-build:shady-->
-                        <div id="background" class="style-scope paper-ripple" style="opacity: 0.0084;"></div>
-		                <div id="waves" class="style-scope paper-ripple"></div>
-                    </paper-ripple>
-                </tp-yt-paper-tab>
-            `);
-            anchorElement.parentNode.insertBefore(newNode, anchorElement);
-            const target = document.querySelector("tp-yt-paper-tab:nth-last-of-type(3)");
+            if (anchorElement) {
+                let displayText = displayTextMap[document.documentElement.lang] || displayTextMap.en;
+                const newNode = document.createRange().createContextualFragment(`
+                    <tp-yt-paper-tab class="style-scope ytd-c4-tabbed-header-renderer" role="tab" aria-disabled="false" aria-selected="true" tabindex="0"><!--css-build:shady-->
+                        <div class="tab-content style-scope tp-yt-paper-tab">${displayText}</div>
+	                    <paper-ripple class="style-scope tp-yt-paper-tab"><!--css-build:shady-->
+                            <div id="background" class="style-scope paper-ripple" style="opacity: 0.0084;"></div>
+		                    <div id="waves" class="style-scope paper-ripple"></div>
+                        </paper-ripple>
+                    </tp-yt-paper-tab>
+                `);
+                anchorElement.parentNode.insertBefore(newNode, anchorElement);
+                const target = document.querySelector("tp-yt-paper-tab:nth-last-of-type(3)");
 
-            target.addEventListener('click', function() {
-                const chId = document.querySelector("ytd-c4-tabbed-header-renderer").__data.data.channelId;
-                const targetURL = `${location.protocol}//${location.host}/playlist?list=${chId.replace(/^UC/, 'UUMO')}`;
-                window.open(targetURL);
-            });
+                target.addEventListener('click', function() {
+                    const chId = document.querySelector("ytd-c4-tabbed-header-renderer").__data.data.channelId;
+                    const targetURL = `${location.protocol}//${location.host}/playlist?list=${chId.replace(/^UC/, 'UUMO')}`;
+                    window.open(targetURL);
+                });
+            }
         }
 
         let targetURL;


### PR DESCRIPTION
Seems YouTube changed something making things loading in different order, which makes actual tab header rendering always happened after loading in my case.
Since MutationObserver will handle that case (in case not using really old browser), just makes first try after loading fail-safe.

Also, youtube changed rerendering behavior, which persist all rendered layout and hide it when not in use.
Only tab header part is rerendered when needed, which subtree+childlist obeserver of document body is unable to monitor (not sure why 🤔)